### PR TITLE
Fix parsing multi-unit video packet

### DIFF
--- a/Sources/NalUnitParser.swift
+++ b/Sources/NalUnitParser.swift
@@ -3,13 +3,12 @@ import CoreMedia
 
 open class NalUnitParser {
 
-    private class var startCode: UnsafeMutablePointer<UInt8> {
-        let start: [UInt8] = [0,0,0,1]
-        let startBuffer = start.withUnsafeBytes { return $0 }
-        let rawPointer = UnsafeMutableRawPointer(mutating: startBuffer.baseAddress!)
-        return rawPointer.bindMemory(to: UInt8.self, capacity: 4)
+    private static let startCodeBuffer: [UInt8] = [0, 0, 0, 1]
+
+    private class var startCode: UnsafePointer<UInt8> {
+        return startCodeBuffer.withUnsafeBufferPointer  { $0.baseAddress! }
     }
-    
+
     open class func unitParser(packet: VideoPacket) -> [NalUnitProtocol] {
         var nalUnits: [NalUnitProtocol] = []
         let length = packet.bufferSize;


### PR DESCRIPTION
There was an issue with parsing video packets with multiple NAL units. The parser was just considering it as a single unit, resulting in info loss and decoder not working properly (e.g. if the video packet contained sps, pps and idr units, they were all treated as a single sps unit).

That was happening because the bytes array created in `startCode` closure expression got deallocated after the closure end, so its reference was not valid anymore, and contained garbage values (e.g. [0,0,0,0] instead of [0,0,0,1]).

Fixing it by retaining the bytes array as a static class member.